### PR TITLE
adding name verification to kmlEditor 

### DIFF
--- a/media/features/js/kmlEditor.js
+++ b/media/features/js/kmlEditor.js
@@ -590,7 +590,7 @@ madrona.features.kmlEditor = (function(){
                 if ( $('#id_name').val() != "" ) {
                     form.trigger('submit');
                 } else {
-                    alert('Please provide a name for your feature.');
+                    alert('Please provide a name.');
                 }                
             });
             el.find('.cancel_button').click(function(){


### PR DESCRIPTION
ensures that the user has provided a value for the Name field before submitting a feature form 
