### PR TITLE
removing trailing forward slash which broke setup.py on windows. (note: ...

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include *.txt
 include *.rst
 recursive-include docs *
 recursive-include utils *
-recursive-exclude docs/.build/ *
+recursive-exclude docs/.build *


### PR DESCRIPTION
... setup.py still breaks on windows unless psycopg2 and python-cjson are removed from requirements.txt.)
