### PR TITLE
adjusting image references to appropriate madrona github url

### DIFF
--- a/madrona/media/common/fixtures/earthLayers.kml
+++ b/madrona/media/common/fixtures/earthLayers.kml
@@ -10,7 +10,7 @@
               <listItemType>checkHideChildren</listItemType>
               <ItemIcon>
                 <state>open closed</state>
-                <href>http://madrona.googlecode.com/svn/trunk/media/common/images/silk/arrow_branch.png</href>
+                <href>https://github.com/Ecotrust/madrona/raw/master/madrona/media/common/images/silk/arrow_branch.png</href>
               </ItemIcon>
             </ListStyle>	       
 	    </Style>
@@ -23,7 +23,7 @@
               <listItemType>checkHideChildren</listItemType>
               <ItemIcon>
                 <state>open closed</state>                
-                <href>http://madrona.googlecode.com/svn/trunk/media/common/images/silk/flag_blue.png</href>
+                <href>https://github.com/Ecotrust/madrona/raw/master/madrona/media/common/images/silk/flag_blue.png</href>
               </ItemIcon>
             </ListStyle>	       
 	    </Style>
@@ -36,7 +36,7 @@
               <listItemType>checkHideChildren</listItemType>
               <ItemIcon>
                 <state>open closed</state>  
-                <href>http://madrona.googlecode.com/svn/trunk/media/common/images/3d_buildings_16px.png</href>
+                <href>https://github.com/Ecotrust/madrona/raw/master/madrona/media/common/images/3d_buildings_16px.png</href>
               </ItemIcon>
             </ListStyle>	       
 	    </Style>
@@ -49,7 +49,7 @@
                 <listItemType>checkHideChildren</listItemType>
                 <ItemIcon>
                     <state>open closed</state>
-                    <href>http://madrona.googlecode.com/svn/trunk/media/common/images/silk/database.png</href>
+                    <href>https://github.com/Ecotrust/madrona/raw/master/madrona/media/common/images/silk/database.png</href>
                 </ItemIcon>
             </ListStyle>
         </Style>


### PR DESCRIPTION
the Google Earth Layer icon images were no longer serving correctly.
changing the href to madrona on github
