### PR TITLE
Disable next while drawing

### DIFF
--- a/docs/cache_clearing.rst
+++ b/docs/cache_clearing.rst
@@ -24,14 +24,18 @@ Clearing your Google Earth cache
 --------------------------------
 
 Sometimes code changes that result in updated KML will require some trial and error.  
+
 At times, such changes will be reflected in your application through a simple browser refresh.  
+
 At other times, these changes may require the clearing of your browser's cache.  
+
 At still other times, it may help to `clear the cache on your Google Earth client <http://support.google.com/earth/bin/answer.py?hl=en&answer=20712>`_ application.  
 
 Additional Strategies
 ---------------------
 
 Additional cache clearing strategies include:
+
  * restarting your web server and refreshing your browser
  * running the management command ``clear_cache`` (clears the django cache)
  * closing the application tab in your browser, clearing the browser cache, and opening the application in a new tab

--- a/madrona/common/templates/common/map.html
+++ b/madrona/common/templates/common/map.html
@@ -296,7 +296,7 @@
                 <p class="poly">
                     To begin defining a shape, press the button below and 
                     click on the map where you would like to place a vertex. 
-                    When finished, double click the last vertex of your shape.
+                    When finished, double-click the last vertex of your shape.
                 </p>
                 <p class="point" style="display:none;">
                     Click on the map where you would like to place this point 
@@ -336,7 +336,7 @@
                     midpoint of a line. <strong>To remove a vertex, double-click on 
                     it.</strong>
                     <br />
-                    When you are done, click on the button below.
+                    When you are done, click the Done Editing button below.
                 </p>
                 <p class="point">
                     To edit this point feature, press the button below and 

--- a/madrona/features/templates/features/form.html
+++ b/madrona/features/templates/features/form.html
@@ -58,6 +58,10 @@
         
         $('#button_prev').click( function() { wizard('prev'); });
         $('#button_next').click( function() { wizard('next'); });
+        $('.draw_shape').click( function() { $('#button_next').addClass('disabled'); });
+        $('.edit_shape').click( function() { $('#button_next').addClass('disabled'); });
+        $('.done_editing').click( function() { $('#button_next').removeClass('disabled'); });
+        
         if (is_spatial == "True") {
             {% if form.errors %}
             step = 2; // form errors exist

--- a/madrona/features/templates/features/form.html
+++ b/madrona/features/templates/features/form.html
@@ -57,10 +57,21 @@
         };
         
         $('#button_prev').click( function() { wizard('prev'); });
-        $('#button_next').click( function() { wizard('next'); });
-        $('.draw_shape').click( function() { $('#button_next').addClass('disabled'); });
-        $('.edit_shape').click( function() { $('#button_next').addClass('disabled'); });
+        $('#button_next').click( function() { 
+            if(!$('#button_next').hasClass('disabled')) {
+                wizard('next'); 
+            }
+        });
+        $('.draw_shape').click( function() { disable_next(); });
+        $('.edit_shape').click( function() { disable_next(); });
         $('.done_editing').click( function() { $('#button_next').removeClass('disabled'); });
+        
+        function disable_next() {
+            if(!$('#button_next').hasClass('disabled')){
+                $('#button_next').addClass('disabled'); 
+            }
+            $('#button_next').attr('disabled', 'disabled'); 
+        }
         
         if (is_spatial == "True") {
             {% if form.errors %}

--- a/madrona/media/manipulators/js/manipulators.js
+++ b/madrona/media/manipulators/js/manipulators.js
@@ -348,6 +348,7 @@ madrona.Manipulator.prototype.enterManipulatedState_ = function(html, success){
     this.render_target_.find('div.manipulated a.edit_shape').removeClass('disabled');
     this.render_target_.find('div.manipulated').show().find('>p')
         .html(html);
+    $('#button_next').removeClass('disabled');
 }
 
 madrona.Manipulator.prototype.isInvalidGeometry = function(){


### PR DESCRIPTION
Experimenting with disabling the Next button while drawing/editing shapes.  An alternative could be to remove the Next button altogether during drawing/editing.  Just throwing this out there as an option...
